### PR TITLE
chore: Add a 0.2.x release for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
   "name": "geojson-flatten",
-  "version": "1.0.0",
+  "version": "0.2.4",
   "description": "transform geojson into single-parts",
   "source": "index.js",
   "main": "dist/index.js",
-  "umd:main": "dist/index.umd.js",
-  "unpkg": "dist/index.umd.js",
-  "module": "dist/index.es.js",
   "files": [
     "index.js",
     "dist",


### PR DESCRIPTION
Per https://github.com/tmcw/geojson-flatten/issues/13

I maintain that webpack is wrong and bad in this case. This is catering to its incorrect behavior.