### PR TITLE
fix: Handle objects without type

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ export default function flatten(gj) {
     case "Point":
     case "Polygon":
     case "LineString":
+    default:
       return [gj];
   }
 }

--- a/tap-snapshots/test-flatten.js-TAP.test.js
+++ b/tap-snapshots/test-flatten.js-TAP.test.js
@@ -5,81 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/flatten.js TAP flatten multigeometry-single.input.geojson > multigeometry-single.input.geojson 1`] = `
-Array [
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        -122.4425587930444,
-        37.80666418607323,
-        0,
-      ],
-      "type": "Point",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        -122.4428379594768,
-        37.80663578323093,
-        0,
-      ],
-      "type": "Point",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        Array [
-          -122.4425587930444,
-          37.80666418607323,
-          0,
-        ],
-        Array [
-          -122.4428379594768,
-          37.80663578323093,
-          0,
-        ],
-      ],
-      "type": "LineString",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        Array [
-          -122.4425509770566,
-          37.80662588061205,
-          0,
-        ],
-        Array [
-          -122.4428340530617,
-          37.8065999493009,
-          0,
-        ],
-      ],
-      "type": "LineString",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-]
-`
-
 exports[`test/flatten.js TAP flatten multigeometry.input.geojson > multigeometry.input.geojson 1`] = `
 Object {
   "features": Array [
@@ -158,49 +83,6 @@ Object {
 }
 `
 
-exports[`test/flatten.js TAP flatten multilinestring-single.input.geojson > multilinestring-single.input.geojson 1`] = `
-Array [
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        Array [
-          0,
-          0,
-        ],
-        Array [
-          1,
-          1,
-        ],
-      ],
-      "type": "LineString",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        Array [
-          2,
-          2,
-        ],
-        Array [
-          3,
-          3,
-        ],
-      ],
-      "type": "LineString",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-]
-`
-
 exports[`test/flatten.js TAP flatten multilinestring.input.geojson > multilinestring.input.geojson 1`] = `
 Object {
   "features": Array [
@@ -247,37 +129,6 @@ Object {
 }
 `
 
-exports[`test/flatten.js TAP flatten multipoint-single.input.geojson > multipoint-single.input.geojson 1`] = `
-Array [
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        0,
-        0,
-      ],
-      "type": "Point",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        1,
-        1,
-      ],
-      "type": "Point",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-]
-`
-
 exports[`test/flatten.js TAP flatten multipoint.input.geojson > multipoint.input.geojson 1`] = `
 Object {
   "features": Array [
@@ -310,65 +161,6 @@ Object {
   ],
   "type": "FeatureCollection",
 }
-`
-
-exports[`test/flatten.js TAP flatten multipolygon-single.input.geojson > multipolygon-single.input.geojson 1`] = `
-Array [
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        Array [
-          0,
-          0,
-        ],
-        Array [
-          1,
-          1,
-        ],
-        Array [
-          4,
-          2,
-        ],
-        Array [
-          0,
-          0,
-        ],
-      ],
-      "type": "Polygon",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-  Object {
-    "geometry": Object {
-      "coordinates": Array [
-        Array [
-          0,
-          0,
-        ],
-        Array [
-          5,
-          5,
-        ],
-        Array [
-          4,
-          2,
-        ],
-        Array [
-          0,
-          0,
-        ],
-      ],
-      "type": "Polygon",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-]
 `
 
 exports[`test/flatten.js TAP flatten multipolygon.input.geojson > multipolygon.input.geojson 1`] = `
@@ -433,18 +225,6 @@ Object {
 }
 `
 
-exports[`test/flatten.js TAP flatten nullgeometry-single.input.geojson > nullgeometry-single.input.geojson 1`] = `
-Array [
-  Object {
-    "geometry": null,
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-]
-`
-
 exports[`test/flatten.js TAP flatten nullgeometry.input.geojson > nullgeometry.input.geojson 1`] = `
 Object {
   "features": Array [
@@ -460,24 +240,6 @@ Object {
 }
 `
 
-exports[`test/flatten.js TAP flatten point-single.input.geojson > point-single.input.geojson 1`] = `
-Array [
-  Object {
-    "geometry": Object {
-      "geometries": Array [
-        0,
-        0,
-      ],
-      "type": "Point",
-    },
-    "properties": Object {
-      "name": "SF Marina Harbor Master",
-    },
-    "type": "Feature",
-  },
-]
-`
-
 exports[`test/flatten.js TAP flatten point.input.geojson > point.input.geojson 1`] = `
 Object {
   "features": Array [
@@ -488,6 +250,26 @@ Object {
           0,
         ],
         "type": "Point",
+      },
+      "properties": Object {
+        "name": "SF Marina Harbor Master",
+      },
+      "type": "Feature",
+    },
+  ],
+  "type": "FeatureCollection",
+}
+`
+
+exports[`test/flatten.js TAP flatten typelesspoint.input.geojson > typelesspoint.input.geojson 1`] = `
+Object {
+  "features": Array [
+    Object {
+      "geometry": Object {
+        "geometries": Array [
+          0,
+          0,
+        ],
       },
       "properties": Object {
         "name": "SF Marina Harbor Master",

--- a/test/fixture/typelesspoint.input.geojson
+++ b/test/fixture/typelesspoint.input.geojson
@@ -1,0 +1,14 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "geometries": [0, 0]
+            },
+            "properties": {
+                "name": "SF Marina Harbor Master"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fixes a case where the function would throw an unexpected `Cannot read property 'map' of undefined` error when given an invalid GeoJson with a missing "type" property.

Now it just doesn't flatten any such object.